### PR TITLE
switched to HTTPS Google fonts

### DIFF
--- a/eatsmart/templates/base.html
+++ b/eatsmart/templates/base.html
@@ -15,7 +15,7 @@
     <link rel="icon" href="{% static 'images/favicon.ico' %}" type="image/x-icon" />
     <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
     <link rel="stylesheet" media="all" href="{% static 'css/site.css' %}">
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'>
     {% block extra-css %}{% endblock %}
     <script src="//cdnjs.cloudflare.com/ajax/libs/modernizr/2.7.1/modernizr.dev.js"></script>
     {% leaflet_js %}


### PR DESCRIPTION
Changed the link to use https in place of http for Google fonts. This fixes a browser error blocking non https content on a secure connection.