### PR TITLE
#158 Only ask to geolocate user on homepage

### DIFF
--- a/eatsmart/templates/base.html
+++ b/eatsmart/templates/base.html
@@ -107,7 +107,7 @@
     <script src="{% static 'js/site.js' %}"></script>
     <script>
       var csrf_token = "{{ csrf_token }}";
-      {% if not request.session.location %}
+      {% if request.path == "/" and not request.session.location %}
         UserGeoLocation.init();
       {% endif %}
     </script>


### PR DESCRIPTION
### Purpose

#158 

This updates the base template so that we only ask to geolocate a user when they're on the homepage (which contains the map). Previously, the geolocation permission request would initiate on the about page, which is somewhat undesirable.

### Approach

I added a check to the `UserGeoLocation.init();` so that it includes a condition that we're currently on the root path (`/`).

Question:

Should this be smarter and check if there's a map initialized in the DOM somehwere?

Closes #158 